### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -1,0 +1,126 @@
+name: Update semantic tags on repo & image after release
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: "${{ github.workflow }}"
+  cancel-in-progress: false # last one must win in case of multiple releases
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  repo-has-container:
+    name: Repo has container?
+    runs-on: ubuntu-latest
+    outputs:
+      has_container: ${{ steps.determine.outputs.has_container }}
+
+    steps:
+      - name: Repo has docker container?
+        id: determine
+        shell: bash
+        run: |
+          HAS_CONTAINER="${{ vars.HAS_CONTAINER }}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> ${GITHUB_OUTPUT}
+
+  retag-containers:
+    name: Retag the containers
+    runs-on: ubuntu-latest
+    needs:
+      - repo-has-container
+    if: |
+      fromJSON(needs.repo-has-container.outputs.has_container) == true
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          npm ci --ignore-scripts
+
+      - name: Download crane tar, extract, and add folder to path.
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const tc = require("@actions/tool-cache");
+
+            const release = await github.rest.repos.getLatestRelease({
+                owner: "google",
+                repo: "go-containerregistry"
+            });
+
+            const asset = release.data.assets.find(asset => {
+                return asset["content_type"] === "application/gzip" && asset.name === "go-containerregistry_Linux_x86_64.tar.gz";
+            });
+
+            const urlToCraneTar = asset.browser_download_url
+
+            const craneTarPath = await tc.downloadTool(urlToCraneTar);
+            const craneExtractedFolder = await tc.extractTar(craneTarPath, null, ["--extract", "--gzip"]);
+
+            core.addPath(craneExtractedFolder);
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set full image name
+        shell: bash
+        run: |
+          echo "FULL_IMAGE_NAME=${REGISTRY,,}/${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+
+      - name: Find all tags for ${{ env.FULL_IMAGE_NAME }}
+        shell: bash
+        run: |
+          crane ls ${FULL_IMAGE_NAME} >> existing_tags
+
+          echo "These are the existing tags on ${FULL_IMAGE_NAME}:"
+          cat existing_tags
+
+      - name: Check if the incoming PR has a Docker container, which will be our old tag
+        shell: bash
+        run: |
+          old_tag=$(cat existing_tags | grep "^sha-${{ github.sha }}-.*\$") # .* is actual or retag
+
+          echo "OLD_TAG=${old_tag}" >> ${GITHUB_ENV}
+
+      - name: Set the new TAGs
+        id: meta
+        uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5.5.0
+        with:
+          images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern=v{{version}}
+
+      - name: Actually re-tag the container
+        shell: bash
+        run: |
+          echo "${{ steps.meta.outputs.tags }}" | while read new_tag
+          do
+            crane cp "${FULL_IMAGE_NAME}:${OLD_TAG}" ${new_tag}
+          done

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -8,7 +8,7 @@ overrides:
       - "**/*.json"
     options:
       tabWidth: 4
-      trailingComma: all
+      trailingComma: none
   - files:
       - "package.json"
       - "package-lock.json"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,9 +23,9 @@
             "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
-                "RUST_LOG": "debug,advent_of_code_2023=trace"
+                "RUST_LOG": "DEBUG,advent_of_code_2023=TRACE"
             },
-            "terminal": "console"
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -47,9 +47,9 @@
             "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
-                "RUST_LOG": "debug,advent_of_code_2023=trace"
+                "RUST_LOG": "DEBUG,advent_of_code_2023=TRACE"
             },
-            "terminal": "console"
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -71,9 +71,9 @@
             "cwd": "${workspaceFolder}",
             "env": {
                 "RUST_BACKTRACE": "1",
-                "RUST_LOG": "debug,advent_of_code_2023=trace"
+                "RUST_LOG": "DEBUG,advent_of_code_2023=TRACE"
             },
-            "terminal": "console"
+            "terminal": "integrated"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.runnables.extraEnv": {
+        "RUST_LOG": "DEBUG,advent_of_code_2023=TRACE"
+    }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,6 @@ repository = "https://github.com/kristof-mattei/advent-of-code-2023"
 keywords = ["playground"]
 categories = ["playground"]
 
-[lib]
-doctest = false
-
-[profile.dev]
-debug = true
-
-[profile.release]
-debug = true
-
-[profile.bench]
-debug = true
-
-[profile.test]
-debug = true
-
 [lints.clippy]
 # don't stop from compiling / running
 all = "warn"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,8 @@
         "@semantic-release/github": "9.2.6",
         "@semantic-release/release-notes-generator": "12.1.0",
         "conventional-changelog-conventionalcommits": "7.0.2",
-        "prettier": "3.2.2",
-        "semantic-release": "23.0.0",
-        "semver": "7.5.4",
-        "serialize-error": "11.0.3"
+        "prettier": "3.2.3",
+        "semantic-release": "23.0.0"
       },
       "engines": {
         "node": ">=20.11.0",
@@ -81,15 +79,6 @@
         "@actions/io": "^1.1.1",
         "semver": "^6.1.0",
         "uuid": "^3.3.2"
-      }
-    },
-    "node_modules/@actions/tool-cache/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -602,6 +591,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@semantic-release/npm/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@semantic-release/release-notes-generator": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.1.0.tgz",
@@ -937,6 +953,33 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/conventional-commits-filter": {
@@ -2132,6 +2175,33 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/normalize-url": {
@@ -5190,9 +5260,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
-      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.3.tgz",
+      "integrity": "sha512-QNhUTBq+mqt1oH1dTfY3phOKNhcDdJkfttHI6u0kj7M2+c+7fmNKlgh2GhnHiqMcbxJ+a0j2igz/2jfl9QKLuw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -5500,7 +5570,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/semver": {
+    "node_modules/semantic-release/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
@@ -5513,6 +5595,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/semver-diff": {
@@ -5530,19 +5621,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/semver-regex": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
-      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
+    "node_modules/semver-diff/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
@@ -5554,28 +5633,28 @@
         "node": ">=10"
       }
     },
-    "node_modules/serialize-error": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
-      "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+    "node_modules/semver-diff/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^2.12.2"
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=10"
       }
     },
-    "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+    "node_modules/semver-regex": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
       "dev": true,
       "engines": {
-        "node": ">=12.20"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
     "@semantic-release/github": "9.2.6",
     "@semantic-release/release-notes-generator": "12.1.0",
     "conventional-changelog-conventionalcommits": "7.0.2",
-    "prettier": "3.2.2",
-    "semantic-release": "23.0.0",
-    "semver": "7.5.4",
-    "serialize-error": "11.0.3"
+    "prettier": "3.2.3",
+    "semantic-release": "23.0.0"
   },
   "publishConfig": {
     "access": "restricted"

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,32 @@
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+module.exports = {
+  plugins: [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "conventionalcommits",
+      },
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        preset: "conventionalcommits",
+      },
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        changelogTitle: "Changelog",
+        changelogFile: "CHANGELOG.md",
+      },
+    ],
+    "@semantic-release/github",
+  ],
+  branches: [
+    {
+      name: "main",
+    },
+  ],
+};


### PR DESCRIPTION
- chore(deps): update actions/upload-artifact action to v3.1.3
- chore(deps): update returntocorp/semgrep docker tag to v1.39.0
- chore(deps): update rust:1.72.0 docker digest to b166ff9
- chore(deps): update coverallsapp/github-action action to v2.2.3
- chore(deps): update rust:1.72.0 docker digest to 535b72c
- chore(deps): update rust:1.72.0 docker digest to fb4f69b
- chore(deps): update rust:1.72.0 docker digest to 8a4ca3c
- chore(deps): update docker/build-push-action action to v4.2.0
- chore(deps): update docker/build-push-action action to v4.2.1
- chore(deps): update actions/cache action to v3.3.2
- chore(deps): update dependency conventional-changelog-conventionalcommits to ^7.0.2
- chore(deps): update npm to v10
- chore(deps): update dependency @semantic-release/github to ^9.0.5
- chore(deps): lock file maintenance
- chore(deps): update docker/setup-buildx-action action to v3
- chore(deps): update docker/login-action action to v3
- chore(deps): update docker/metadata-action action to v5
- chore(deps): update docker/build-push-action action to v5
- chore(deps): update github/codeql-action action to v2.21.6
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 3d6ac10
- chore(deps): update github/codeql-action action to v2.21.7
- chore(deps): update dependency @semantic-release/github to ^9.0.6
- chore(deps): update returntocorp/semgrep docker tag to v1.40.0
- chore(deps): update dependency semantic-release to ^21.1.2
- chore(deps): lock file maintenance
- chore(deps): update dependency semantic-release to v22
- chore(deps): update semantic-release monorepo
- chore(deps): update node.js to >=v18.18.0
- chore(deps): update returntocorp/semgrep docker tag to v1.41.0
- chore(deps): update github/codeql-action action to v2.21.8
- chore(deps): update rust docker tag to v1.72.1
- chore(deps): update rust to v1.72.1
- chore(deps): update rust:1.72.1 docker digest to 1a03e33
- chore(deps): update rust:1.72.1 docker digest to 0935c74
- chore(deps): update rust:1.72.1 docker digest to d601f6c
- chore(deps): update dependency semantic-release to ^22.0.1
- chore(deps): update rust:1.72.1 docker digest to 911acdf
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.10.0
- chore(deps): update actions/checkout action to v4.1.0
- chore(deps): update dependency semantic-release to ^22.0.4
- chore(deps): update dependency @semantic-release/github to ^9.0.7
- chore(deps): update dependency semantic-release to ^22.0.5
- chore(deps): lock file maintenance
- chore(deps): update dependency @semantic-release/github to ^9.1.0
- chore(deps): update dependency @semantic-release/github to ^9.2.0
- chore(deps): update github/codeql-action action to v2.21.9
- chore(deps): update dependency @semantic-release/github to ^9.2.1
- chore(deps): update actions-rs-plus/clippy-check action to v2.1.1
- fix: workflow_dispatch does not take a branch
- chore(deps): update alpine docker tag to v3.18.4
- chore(deps): update returntocorp/semgrep docker tag to v1.42.0
- chore(deps): lock file maintenance
- chore(deps): update npm to >=10.2.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 05a0d13
- chore(deps): update returntocorp/semgrep docker tag to v1.43.0
- chore(deps): update rust to v1.73.0
- chore(deps): update github/codeql-action action to v2.22.0
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v2.22.1
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.11.0
- chore(deps): update node.js to >=18.18.1
- chore(deps): update returntocorp/semgrep docker tag to v1.44.0
- chore(deps): update github/codeql-action action to v2.22.2
- chore(deps): update rust:1.73.0 docker digest to 1fd670f
- chore(deps): update rust:1.73.0 docker digest to 0b82242
- chore(deps): update rust:1.73.0 docker digest to 054d687
- chore(deps): update rust:1.73.0 docker digest to 73af736
- chore(deps): update github/codeql-action action to v2.22.3
- chore(deps): update node.js to >=18.18.2
- chore(deps): lock file maintenance
- chore(deps): update actions/checkout action to v4.1.1
- chore(deps): pin dependencies
- chore(deps): update npm to >=10.2.1
- chore(deps): update returntocorp/semgrep docker tag to v1.45.0
- chore(deps): update github/codeql-action action to v2.22.4
- chore(deps): lock file maintenance
- chore(deps): update actions/setup-node action to v3.8.2
- chore(deps): update actions/setup-node action to v4
- chore(deps): update node.js to v20
- chore(deps): update node.js to >=20.9.0
- chore(deps): update returntocorp/semgrep docker tag to v1.46.0
- chore: move to node 20, make backtrace always compile release as we don't care about their internals
- chore(deps): update github/codeql-action action to v2.22.5
- chore(deps): lock file maintenance
- chore(deps): update dependency semantic-release to v22.0.6
- chore(deps): update npm to >=10.2.2
- chore(deps): update rust:1.73.0 docker digest to 0dc5fcb
- chore(deps): update rust:1.73.0 docker digest to 4e0bd79
- chore(deps): update rust:1.73.0 docker digest to 25fa7a9
- chore(deps): update returntocorp/semgrep docker tag to v1.47.0
- fix: fix new version
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 066878f
- chore(deps): update npm to >=10.2.3
- chore(deps): update dependency semantic-release to v22.0.7
- chore(deps): update dependency @semantic-release/release-notes-generator to v12.0.1
- chore(deps): lock file maintenance
- chore(deps): update semantic-release monorepo
- chore(deps): update returntocorp/semgrep docker tag to v1.48.0
- chore(deps): update dependency @semantic-release/github to v9.2.2
- chore(deps): update dependency @semantic-release/github to v9.2.3
- chore(deps): update dependency serialize-error to v11.0.3
- chore(deps): lock file maintenance
- chore(deps): update dependency prettier to v3.1.0
- chore(deps): update actions/github-script action to v7
- chore(deps): update github/codeql-action action to v2.22.6
- chore(deps): update returntocorp/semgrep docker tag to v1.49.0
- chore(deps): update npm to >=10.2.4
- chore(deps): update github/codeql-action action to v2.22.7
- chore(deps): update rust to v1.74.0
- chore(deps): update dependency semantic-release to v22.0.8
- chore(deps): update returntocorp/semgrep docker tag to v1.50.0
- chore(deps): update docker/build-push-action action to v5.1.0
- chore(deps): update actions/github-script action to v7.0.1
- chore(deps): update actions-rs-plus/clippy-check action to v2.2.1
- chore(deps): update actions-rs-plus/clippy-check action to v2.2.2
- chore(deps): roll back actions-rs-plus/clippy-check action to v2.2.0
- chore: use lints
- chore: DENY uninlined format args
- chore: ALLOW uninlined format args
- chore: remove redundant quotes
- chore: bump uninlined format args priority
- chore(deps): lock file maintenance
- chore: add mold, use lints
- chore: restore backtrace always optimize
- chore: fix typo
- chore: pin mold
- chore(deps): update rui314/setup-mold digest to 89146af
- chore(deps): update rust:1.74.0 docker digest to 6de6071
- chore(deps): update node.js to >=20.10.0
- chore(deps): update github/codeql-action action to v2.22.8
- fix: add placeholder for env variable
- chore(deps): lock file maintenance
- chore: disable function-next-line formatting, it looks weird
- chore: rename nextversion to next_version
- chore(deps): update returntocorp/semgrep docker tag to v1.51.0
- chore(deps): update dependency @semantic-release/github to v9.2.4
- chore(deps): update docker/metadata-action action to v5.1.0
- chore(deps): update docker/metadata-action action to v5.2.0
- chore(deps): update rui314/setup-mold digest to 6a9a134
- chore(deps): update alpine docker tag to v3.18.5
- chore(deps): lock file maintenance
- chore(deps): update docker/metadata-action action to v5.3.0
- chore(deps): update dependency semantic-release to v22.0.9
- chore(deps): update returntocorp/semgrep docker tag to v1.52.0
- chore(deps): update dependency semantic-release to v22.0.10
- chore(deps): update npm to >=10.2.5
- chore(deps): update github/codeql-action action to v2.22.9
- chore(deps): update dependency @semantic-release/github to v9.2.5
- chore(deps): update rust docker tag to v1.74.1
- chore(deps): update alpine docker tag to v3.19.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 4ae1575
- chore(deps): update dependency prettier to v3.1.1
- chore(deps): lock file maintenance
- chore(deps): update dependency semantic-release to v22.0.11
- chore(deps): update dependency semantic-release to v22.0.12
- chore(deps): update github/codeql-action action to v2.22.10
- chore(deps): update returntocorp/semgrep docker tag to v1.53.0
- chore(deps): update github/codeql-action action to v2.22.11
- chore(deps): update github/codeql-action action to v3
- chore(deps): update actions/upload-artifact action to v4
- chore(deps): update actions/download-artifact action to v4
- chore(deps): lock file maintenance
- chore(deps): update actions/setup-node action to v4.0.1
- chore(deps): update docker/metadata-action action to v5.4.0
- chore(deps): update rust to v1.74.1
- chore(deps): update actions/download-artifact action to v4.1.0
- chore(deps): update rust:1.74.1 docker digest to 44dd40c
- chore(deps): update rust:1.74.1 docker digest to 0bb7cf3
- chore(deps): update rust:1.74.1 docker digest to fd45a54
- chore(deps): update returntocorp/semgrep docker tag to v1.54.0
- chore(deps): update returntocorp/semgrep docker tag to v1.54.1
- chore(deps): update returntocorp/semgrep docker tag to v1.54.2
- chore(deps): update github/codeql-action action to v3.22.12
- chore(deps): update rui314/setup-mold digest to a06ef65
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.12.0
- chore(deps): update dependency @semantic-release/github to v9.2.6
- chore(deps): update returntocorp/semgrep docker tag to v1.54.3
- chore(deps): lock file maintenance
- chore(deps): update rust to v1.75.0
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.55.0
- chore(deps): update returntocorp/semgrep docker tag to v1.55.1
- chore(deps): update docker/metadata-action action to v5.5.0
- chore(deps): update returntocorp/semgrep docker tag to v1.55.2
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v3.23.0
- chore(deps): update node.js to >=20.11.0
- chore(deps): update actions/download-artifact action to v4.1.1
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to a0435af
- chore(deps): update npm to >=10.3.0
- chore(deps): update returntocorp/semgrep docker tag to v1.56.0
- chore(deps): update rust:1.75.0 docker digest to 13fda46
- chore(deps): update rust:1.75.0 docker digest to 41c2fff
- chore(deps): update actions/cache action to v3.3.3
- chore(deps): update rust:1.75.0 docker digest to 2f73302
- chore(deps): update rust:1.75.0 docker digest to ea94653
- chore(deps): update actions/upload-artifact action to v4.1.0
- chore(deps): update dependency prettier to v3.2.1
- chore: ensure run and debug from main add the right LOG settings
- chore: console isn't useful, updated casing of levels
- chore(deps): update dependency semantic-release to v23
- chore(deps): update rust:1.75.0 docker digest to 1c5eaf3
- fix: move semantic-release config file as per https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0
- fix: mixed up config name order
- fix: simplified tags
- test: trigger build
- fix: cleanup
- chore(deps): update rust:1.75.0 docker digest to c09b1bb
- chore(deps): update dependency prettier to v3.2.2
- chore(deps): lock file maintenance
- chore(deps): update rust:1.75.0 docker digest to b168e2c
- chore(deps): update rust:1.75.0 docker digest to 184a309
- chore: no trailing commas in json
- chore(deps): update dependency prettier to v3.2.3
