### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -34,8 +34,17 @@ jobs:
         run: |
           semgrep ci --sarif --output=semgrep.sarif
 
+      - name: Fixup semgrep.sarif's startColumn==0 and/or endColumn==0
+        shell: bash
+        run: |
+          jq '.' semgrep.sarif > normalized.sarif
+          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.startColumn==0) | .startColumn)' normalized.sarif > fixed_start_column.sarif
+          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.endColumn==0) | .endColumn)' fixed_start_column.sarif > fixed_start_end_column.sarif
+
+          diff normalized.sarif fixed_start_end_column.sarif || true
+
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
         uses: github/codeql-action/upload-sarif@e675ced7a7522a761fc9c8eb26682c8b27c42b2b # v3.24.1
         with:
-          sarif_file: semgrep.sarif
+          sarif_file: fixed_start_end_column.sarif


### PR DESCRIPTION
- chore(deps): update rust:1.75.0 docker digest to 755b46a
- chore(deps): update dependency prettier to v3.2.4
- chore(deps): update github/codeql-action action to v3.23.1
- chore(deps): update actions/cache action to v4
- chore(deps): update rust:1.75.0 docker digest to 2176747
- chore(deps): update rust:1.75.0 docker digest to 166aa82
- chore(deps): update rust:1.75.0 docker digest to ac8c4cb
- chore(deps): update returntocorp/semgrep docker tag to v1.57.0
- chore(deps): update actions/upload-artifact action to v4.2.0
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.58.0
- chore(deps): update actions/upload-artifact action to v4.3.0
- chore(deps): update dorny/paths-filter action to v2.12.0
- chore(deps): update npm to >=10.4.0
- chore(deps): update dorny/paths-filter action to v3
- chore(deps): update github/codeql-action action to v3.23.2
- chore(deps): update alpine docker tag to v3.19.1
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.59.0
- chore(deps): update docker/metadata-action action to v5.5.1
- chore(deps): update rust:1.75.0 docker digest to 503aee4
- chore(deps): update rust:1.75.0 docker digest to e173089
- chore(deps): update rust:1.75.0 docker digest to fb477b5
- chore(deps): update returntocorp/semgrep docker tag to v1.59.1
- chore(deps): update github/codeql-action action to v3.24.0
- chore: use internal console, not the terminal for debugging
- chore(deps): update rust:1.75.0 docker digest to 87f3b2f
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.13.0
- chore(deps): update dependency prettier to v3.2.5
- chore(deps): lock file maintenance
- chore(deps): update actions/download-artifact action to v4.1.2
- chore(deps): update actions/upload-artifact action to v4.3.1
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.14.0
- chore(deps): update dependency semantic-release to v23.0.1
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 64161ff
- chore(deps): update actions/setup-node action to v4.0.2
- chore(deps): update dependency semantic-release to v23.0.2
- chore(deps): update rust to v1.76.0
- chore(deps): update returntocorp/semgrep docker tag to v1.60.1
- chore(deps): update rust:1.76.0 docker digest to 8e87602
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v3.24.1
- chore(deps): update rust:1.76.0 docker digest to 3e95fdb
- chore(deps): update returntocorp/semgrep docker tag to v1.61.0
- chore(deps): update rust:1.76.0 docker digest to 01752fc
- chore(deps): update rust:1.76.0 docker digest to 3c1dc1b
- chore: fix startColumn/endColumn being 0. Is invalid. Normalize json file for diffing, ignore output. Diff is expected
