### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  semgrep:
+  scan:
     name: Scan
     runs-on: ubuntu-latest
 
@@ -32,6 +32,25 @@ jobs:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
         run: |
           semgrep ci --sarif --output=semgrep.sarif
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: semgrep.sarif # name of the artifact
+          path: semgrep.sarif # path of the file to be part of the artifact (think file added to a zip)
+
+  upload:
+    name: Upload
+    runs-on: ubuntu-latest
+    needs:
+      - scan
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: semgrep.sarif # name of the artifact
+          path: . # WHERE to unpack all files part of the artifact
 
       - name: Fixup semgrep.sarif's startColumn==0 and/or endColumn==0
         shell: bash


### PR DESCRIPTION
- **fix: separate scan and fixup, as the scan container doesn't have bash / jq anymore**
- **fix: only upload sarif file itself**
- **fix: set unpack folder, not filepath**
