### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  scan:
+  semgrep:
     name: Scan
     runs-on: ubuntu-latest
 
@@ -33,42 +33,8 @@ jobs:
         run: |
           semgrep ci --sarif --output=semgrep.sarif
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        with:
-          name: semgrep.sarif # name of the artifact
-          path: semgrep.sarif # path of the file to be part of the artifact (think file added to a zip)
-
-  upload:
-    name: Upload
-    runs-on: ubuntu-latest
-    needs:
-      - scan
-
-    steps:
-      # this checkout satisfies github/codeql-action's need for certain variables to link the sarif to the right commit sha
-      - name: Checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-        with:
-          show-progress: false
-
-      - name: Download artifact
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
-        with:
-          name: semgrep.sarif # name of the artifact
-          path: . # WHERE to unpack all files part of the artifact
-
-      - name: Fixup semgrep.sarif's startColumn==0 and/or endColumn==0
-        shell: bash
-        run: |
-          jq '.' semgrep.sarif > normalized.sarif
-          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.startColumn==0) | .startColumn)' normalized.sarif > fixed_start_column.sarif
-          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.endColumn==0) | .endColumn)' fixed_start_column.sarif > fixed_start_end_column.sarif
-
-          diff normalized.sarif fixed_start_end_column.sarif || true
-
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
         uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
         with:
-          sarif_file: fixed_start_end_column.sarif
+          sarif_file: semgrep.sarif

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "advent-of-code-2023"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2021"
-rust-version = "1.76.0"
+rust-version = "1.77.0"
 authors = ["Kristof Mattei"]
 license-file = "LICENSE"
 description = "Advent of Code 2023"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76.0@sha256:d36f9d8a9a4c76da74c8d983d0d4cb146dd2d19bb9bd60b704cdcf70ef868d3a as builder
+FROM rust:1.77.0@sha256:00e330d2e2cdada2b75e9517c8359df208b3c880c5e34cb802c120083d50af35 as builder
 
 ARG TARGET=x86_64-unknown-linux-musl
 ARG APPLICATION_NAME

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.16.1**
- **chore(deps): update rust to v1.77.0**
- **chore(deps): update github/codeql-action action to v3.24.9**
- **chore: rename semgrep job to make it register with semgrep**
- **chore: use semgrep action, not container**
- **chore(deps): update returntocorp/semgrep-action digest to 713efdd**
- **chore: back to container, the action is outdated**
- **chore: add category**
- **chore: semgrep 1 job**
- **chore: fix filename**
