### PR TITLE
update from upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".vscode/rust-prettifier-for-lldb"]
+	path = .vscode/rust-prettifier-for-lldb
+	url = https://github.com/cmrschwarz/rust-prettifier-for-lldb

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 .git
-.github/actions/
+.mypy_cache
+.vscode/rust-prettifier-for-lldb
 CHANGELOG.md
 profiling
 reports

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,8 +25,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,advent_of_code_2023=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -50,8 +50,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,advent_of_code_2023=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -75,8 +75,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,advent_of_code_2023=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         }
     ]
 }

--- a/.vscode/rust_prettifier_for_lldb.py
+++ b/.vscode/rust_prettifier_for_lldb.py
@@ -1,0 +1,1 @@
+./rust-prettifier-for-lldb/rust_prettifier_for_lldb.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,11 @@
 {
-    "debug.internalConsoleOptions": "openOnSessionStart",
+    "debug.internalConsoleOptions": "neverOpen",
+    "lldb.launch.terminal": "integrated",
+    "lldb.launch.expressions": "simple",
+    "lldb.launch.preRunCommands": [
+        "command script import ${workspaceFolder}/.vscode/rust_prettifier_for_lldb.py"
+    ],
     "prettier.configPath": "./.prettierrc.cjs",
-    "rust-analyzer.debug.engineSettings": {
-        "lldb": {
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
-        }
-    },
-    "rust-analyzer.debug.openDebugPane": true,
     "rust-analyzer.runnables.extraEnv": {
         "RUST_LOG": "DEBUG,advent_of_code_2023=TRACE"
     }


### PR DESCRIPTION
- **chore(deps): update rust:1.86.0 docker digest to 563b33d**
- **chore(deps): update dependency prettier-plugin-sh to v0.16.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v3.28.14**
- **chore(deps): update github/codeql-action action to v3.28.15**
- **chore(deps): update rust:1.86.0 docker digest to 2494472**
- **chore(deps): update rust:1.86.0 docker digest to 6a6dda6**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.0**
- **chore(deps): update npm to >=11.3.0**
- **chore(deps): update rust:1.86.0 docker digest to 9fdf93f**
- **chore(deps): update rust:1.86.0 docker digest to 7b65306**
- **chore(deps): update returntocorp/semgrep docker tag to v1.118.0**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.1**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.2**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to a87c2e8**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/setup-node action to v4.4.0**
- **chore(deps): update codecov/codecov-action action to v5.4.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.119.0**
- **chore(deps): update softprops/action-gh-release action to v2.2.2**
- **chore(deps): lock file maintenance**
- **fix: start tracking lldb debug helper**
- **chore(deps): update returntocorp/semgrep docker tag to v1.120.0**
- **chore(deps): update github/codeql-action action to v3.28.16**
- **chore(deps): update node.js to v22.15.0**
- **chore(deps): update docker/build-push-action action to v6.16.0**
- **chore(deps): update actions/download-artifact action to v4.3.0**
- **chore: set default debug visualizer**
- **chore: update debug setup**
