### PR TITLE
update from upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,20 @@ keywords = ["playground"]
 repository = "https://github.com/kristof-mattei/advent-of-code-2023"
 include = ["src/**", "/LICENSE", "/LICENSE-*"]
 
+[dependencies]
+color-eyre = "0.6.5"
+hashbrown = { version = "0.15.4", default-features = false, features = [
+    "default-hasher",
+    "inline-more",
+    "equivalent",
+] }
+regex = { version = "1.11.1", default-features = false, features = [
+    "perf",
+    "unicode-perl",
+    "std",
+    "unicode-case",
+] }
+
 [lints.clippy]
 # don't stop from compiling / running
 all = "warn"
@@ -39,7 +53,8 @@ allow_attributes = { level = "deny", priority = 127 }
 allow_attributes_without_reason = { level = "deny", priority = 127 }
 # Debatable
 # arithmetic_side_effects = { level = "deny", priority = 127 }
-as_conversions = { level = "deny", priority = 127 }
+# Debatable
+# as_conversions = { level = "deny", priority = 127 }
 as_pointer_underscore = { level = "deny", priority = 127 }
 as_underscore = { level = "deny", priority = 127 }
 assertions_on_result_states = { level = "deny", priority = 127 }
@@ -79,7 +94,6 @@ inline_asm_x86_att_syntax = { level = "deny", priority = 127 }
 # integer_division = { level = "deny", priority = 127 }
 # Debatable
 # integer_division_remainder_used = { level = "deny", priority = 127 }
-iter_over_hash_type = { level = "deny", priority = 127 }
 large_include_file = { level = "deny", priority = 127 }
 let_underscore_must_use = { level = "deny", priority = 127 }
 let_underscore_untyped = { level = "deny", priority = 127 }
@@ -176,17 +190,3 @@ uninlined-format-args = { level = "allow", priority = 127 }
 [lints.rust]
 let_underscore_drop = { level = "deny", priority = 127 }
 non_ascii_idents = { level = "deny", priority = 127 }
-
-[dependencies]
-color-eyre = "0.6.5"
-hashbrown = { version = "0.15.4", default-features = false, features = [
-    "default-hasher",
-    "inline-more",
-    "equivalent",
-] }
-regex = { version = "1.11.1", default-features = false, features = [
-    "perf",
-    "unicode-perl",
-    "std",
-    "unicode-case",
-] }


### PR DESCRIPTION
- **chore(deps): update rui314/setup-mold digest to 702b190**
- **fix: we know that sort order when iterating over hash-type isn't guaranteed**
- **chore: move deps, disable as_conversions, too broad**
