### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/graduate-release.yml
+++ b/.github/workflows/graduate-release.yml
@@ -113,17 +113,19 @@ jobs:
             mv release-notes-truncated.md release-notes.md
           fi
 
-          prerelease_args=()
+          release_args=()
           if [ "${PRERELEASE}" == "true" ]; then
-            prerelease_args+=(--prerelease)
+            # prereleases cannot be set as latest
+            release_args+=(--prerelease)
+          else
+            release_args+=(--latest)
           fi
 
           gh release create "${TAG}" \
             --notes-file release-notes.md \
             --title "${TAG}" \
             --verify-tag \
-            --latest \
-            "${prerelease_args[@]}"
+            "${release_args[@]}"
 
       - name: Close stale release PRs
         if: steps.check_release.outputs.exists == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
           # GITHUB_TOKEN attributes the API commit to github-actions[bot].
           # But we push the branch using the checkout PAT so workflows trigger.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # git-cliff reads GITHUB_TOKEN from the environment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           latest_tag=$(git describe --tags --abbrev=0 || true)
 
@@ -98,13 +100,13 @@ jobs:
           fi
 
           bump_flag="auto"
-          bumped=$(git-cliff --bumped-version --bump ${bump_flag} --unreleased --github-token ${{ secrets.GITHUB_TOKEN }})
+          bumped=$(git-cliff --bumped-version --bump ${bump_flag} --unreleased)
 
           # If git-cliff didn't bump (e.g. chore/ci only commits), force a patch increment
           # so we never release the same version as the last tag.
           if [ "${bumped}" = "${latest_tag}" ]; then
             bump_flag="patch"
-            bumped=$(git-cliff --bumped-version --bump patch --unreleased --github-token ${{ secrets.GITHUB_TOKEN }})
+            bumped=$(git-cliff --bumped-version --bump patch --unreleased)
             echo "::notice::No conventional bump detected, forcing patch bump"
           fi
 
@@ -160,7 +162,7 @@ jobs:
 
           commit_message="chore(release): prepare for ${release_version}"
 
-          git-cliff --output CHANGELOG.md --tag "${release_version}" --github-token ${{ secrets.GITHUB_TOKEN }}
+          git-cliff --output CHANGELOG.md --tag "${release_version}"
 
           main_sha=$(git rev-parse HEAD)
 
@@ -213,7 +215,7 @@ jobs:
           # Build the PR-body changelog from a context whose compare-link target
           # is the release-branch head SHA, because the ${release_version} tag
           # doesn't exist until after this PR is merged.
-          git-cliff --context --unreleased --tag "${release_version}" --github-token ${{ secrets.GITHUB_TOKEN }} \
+          git-cliff --context --unreleased --tag "${release_version}" \
             | jq --arg sha "${release_sha}" '.[0].extra = {compare_to: $sha}' \
             > diff-context.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,10 @@ jobs:
 
           git push origin --delete "${branch}-staging" || true
 
-          # Deleting the release branch would close its PR, so keep it when one exists
-          if [ -z "$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')" ]; then
+          # Deleting the release branch would close its PR, so keep it when one exists.
+          # A failing `gh pr list` fails the step (set -e) instead of counting as "no PR".
+          open_pr=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')
+
+          if [ -z "${open_pr}" ]; then
             git push origin --delete "${branch}" || true
           fi


### PR DESCRIPTION
- **chore(ci): pass the github token to git-cliff via the environment**
- **chore(ci): only mark stable releases as latest**
